### PR TITLE
Add line folding

### DIFF
--- a/stringify.ts
+++ b/stringify.ts
@@ -1,8 +1,11 @@
 export type ContentLine = [string, string];
 
+function foldLine(line: string) {
+  return line.match(/(.{1,75})/g)!.join('\r\n ');
+}
+
 function stringifyLine(line: ContentLine) {
-  // TODO: Handle lines longer than 75 bytes
-  return `${line[0]}:${line[1]}`;
+  return foldLine(`${line[0]}:${line[1]}`);
 }
 
 export function stringifyLines(lines: ContentLine[]) {


### PR DESCRIPTION
Hello, I was looking for an easy to use Deno iCal library and when I found this module, I skimmed over the source code to see how it works and I found that there was a `TODO` for line folding, so I just copied [the way sebbo2002/ical-generator does it](https://github.com/sebbo2002/ical-generator/blob/6b8a302553a9658d18548969ee618d4b0f38ed2f/lib/_tools.js#L134-L136).

This method uses a regex to split the line into strings of length 1-75 and then joins them together with `\r\n `. This could also be achieved by using a loop but the regex solution just looks better to me ¯\\_(ツ)_/¯